### PR TITLE
fix sentry errors

### DIFF
--- a/app/megatron/api.py
+++ b/app/megatron/api.py
@@ -223,6 +223,8 @@ def edit(request):
     params = {"new_msg": new_message, "old_msg": old_message}
     update_action = Action(ActionType.UPDATE_MESSAGE, params)
     response = integration_connection.take_action(update_action)
+    if not response.ok:
+        return response
 
     existing_message.customer_msg_id = data["message"]["ts"]
     existing_message.integration_msg_id = response["ts"]

--- a/app/megatron/commands/command_actions.py
+++ b/app/megatron/commands/command_actions.py
@@ -331,7 +331,6 @@ def _update_channel_link(
     ).first()
 
     if not megatron_channel:
-        integration_connection._refresh_access_token(platform_user.platform_id)
         username = platform_user.username + "_" + platform_user.workspace.domain
         username = re.sub(r"[^\w-]", "", username.lower())
         response = integration_connection.create_channel(
@@ -350,6 +349,7 @@ def _update_channel_link(
             _get_conversation_history(megatron_channel)
 
     elif megatron_channel.is_archived:
+        integration_connection._refresh_access_token(platform_user.platform_id)
         MegatronChannelService(megatron_channel).unarchive()
         _get_conversation_history(megatron_channel)
 

--- a/app/megatron/interpreters/slack/api.py
+++ b/app/megatron/interpreters/slack/api.py
@@ -101,7 +101,7 @@ def slash_command(request):
     # TODO: There is only ever one megatron user, remove it
     megatron_user = MegatronUser.objects.first()
 
-    args = data["text"].split(" ")
+    args = data["text"].strip().split(" ")
     command_str = args[0]
     command = Command.get_command(command_str)
     if not command:


### PR DESCRIPTION
Three small errors:
-The workspace was refreshed when creating it instead of when unarchive it (token error)
-Sometimes CS added a space after the commands so strip it lol
-check the response after an edit error to stop execution (I saw it and this happens just when the CS channel gets archived and the bot edit order was already sent. No big deal at all)