### PR TITLE
parametrize DEBUG and django SECRET_KEY

### DIFF
--- a/app/django-variables.env.default
+++ b/app/django-variables.env.default
@@ -1,14 +1,15 @@
+DJANGO_PORT=8002
+MEGATRON_DJANGO_SECRET=fvt96hs34)x$kp%b4u^042g89s&t4ehw7#3fdl7udw+8^$%nm(
+HOSTNAME=https://somename.ngrok.io
+MEGATRON_APP_MODE=megatron-dev
 PYTHONUNBUFFERED=1
 
-DJANGO_PORT=8002
-HOSTNAME=https://somename.ngrok.io
 DATABASE_URL=postgres://postgres:@localhost:5432/local_megatron
 REDIS_URL=redis://localhost:6379
+
 CHANNEL_PREFIX=zz-stage-
 MEGATRON_VERIFICATION_TOKEN=GET_FROM_SLACK
-MEGATRON_APP_MODE=megatron-dev
 
 S3_AWS_ACCESS_KEY_ID=secret
 S3_AWS_SECRET_ACCESS_KEY=access_key
 AWS_S3_BUCKET=some_bucket
-

--- a/app/megatron/settings.py
+++ b/app/megatron/settings.py
@@ -2,8 +2,9 @@ import os
 import re
 from megatron.statics import NotificationChannels
 
-DEBUG = True
-SECRET_KEY = "4l0ngs3cr3tstr1ngw3lln0ts0lj0ngw41tn0w1tsl0ng3n0ugh"
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = os.environ["MEGATRON_DJANGO_SECRET"]
+
 ROOT_URLCONF = "megatron.urls"
 CHANNEL_PREFIX = os.environ["CHANNEL_PREFIX"]
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -15,7 +16,9 @@ INSTALLED_APPS = [
     "megatron",
 ]
 
-MEGATRON_APP_MODE = os.environ.get("MEGATRON_APP_MODE", "dev")
+# Format: `megatron-ENVIRONMENT`
+MEGATRON_APP_MODE = os.environ["MEGATRON_APP_MODE"]
+DEBUG = MEGATRON_APP_MODE == "megatron-dev"
 
 STATIC_ROOT = os.path.join(BASE_DIR, "static/")
 STATIC_URL = "/static/"


### PR DESCRIPTION
Public part of https://app.shortcut.com/teampay/story/26713/update-megatron-public-and-private-to-parameterize-secret-key and https://app.shortcut.com/teampay/story/26710/megatron-don-t-set-debug-true-for-all-environments

Not doing the parameter store SSM part yet since that happens in the private fork. I'll do it after pulling this repo